### PR TITLE
Add ability to add comments to .vendor_urls

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,18 +5,20 @@ indent() {
   sed -u 's/^/       /'
 }
 
-echo "-----> Found a .vendor_urls file"
-
 # Bail early but noisily
 if [ ! -s $1/.vendor_urls ]; then
   echo ".vendor_urls empty. Skipping." | indent
   exit 0
 fi
 
+echo "-----> Found a .vendor_urls file"
+
 cd $1
 
+ignore_comments='^[[:blank:]]*#'
+
 while read url; do
-  if [ -n "$url" ]; then # incase ensure_newline_at_eof_on_save is enabled
+  if [ -n "$url" ] && [[ ! $url =~ $ignore_comments ]]; then # incase ensure_newline_at_eof_on_save is enabled
     echo Vendoring $url | indent
 
     extension="${url##*.}" # http://stackoverflow.com/q/965053


### PR DESCRIPTION
Asana task: https://app.asana.com/0/8628054875474/936053184300546

Add the ability to add comments in the .vendor_urls file so we do not get errors on heroku deploy